### PR TITLE
fixing resource share arn double derp ram to tgw to enable sharing of tgw to list of principals

### DIFF
--- a/modules/aws/tgw/main.tf
+++ b/modules/aws/tgw/main.tf
@@ -24,11 +24,11 @@ resource "aws_ram_resource_share" "this" {
 resource "aws_ram_resource_association" "this" {
   count              = local.ram_enabled ? 1 : 0
   resource_arn       = aws_ec2_transit_gateway.this[0].arn
-  resource_share_arn = aws_ec2_transit_gateway.this[0].arn
+  resource_share_arn = aws_ram_resource_share.this[0].arn
 }
 
 resource "aws_ram_principal_association" "this" {
   count              = local.enabled ? length(var.ram_principals) : 0
   principal          = var.ram_principals[count.index]
-  resource_share_arn = aws_ec2_transit_gateway.this[0].arn
+  resource_share_arn = aws_ram_resource_share.this[0].arn
 }


### PR DESCRIPTION
please validate that tgw module can enable sharing to list of principals via ram